### PR TITLE
Fix #92: Only rebuild changed Docker versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: docker-library/bashbrew@v0.1.12
       - id: generate-jobs
         name: Generate Jobs
@@ -27,6 +29,17 @@ jobs:
           # If triggered by a cron event, filter strategy to include `unstable` and `unstable-alpine`
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             strategy=$(jq -c '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name =="unstable" or .name== "unstable-alpine")]}}' <<<"$strategy")
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/mainline" ]]; then
+            # For pushes to mainline, only build changed versions
+            changed_files=$(git diff --name-only HEAD~1 HEAD)
+            if echo "$changed_files" | grep -qE "^(versions\.json|[0-9]+\.[0-9]+/|unstable/)"; then
+              changed_versions=$(echo "$changed_files" | grep -oE "^[0-9]+\.[0-9]+|^unstable" | sort -u | tr '\n' '|' | sed 's/|$//')
+              if [[ -n "$changed_versions" ]]; then
+                strategy=$(jq -c --arg versions "$changed_versions" '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name | test($versions))]}}' <<<"$strategy")
+              fi
+            else
+              strategy='{"fail-fast": false, "matrix": {"include": []}}'
+            fi
           fi
 
           echo "strategy=$strategy" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- Add change detection for manual pushes to mainline
- Filter build strategy to only include changed versions
- Skip builds when only documentation changes
- Reduces unnecessary rebuilds from 10 images to 2-4 images